### PR TITLE
fix: take public visible theme repository into account

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -2,10 +2,8 @@
 name: Deploy Hugo site to Pages
 
 on:
-    # Runs on pushes targeting the default branch
+    # Runs on pushes
     push:
-        branches:
-            - main
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
@@ -38,25 +36,11 @@ jobs:
               run: |
                   wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
                   && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-            # - name: Checkout
-            #   uses: actions/checkout@v4
-            #   with:
-            #     submodules: recursive
-            #     fetch-depth: 0
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Clone Submodule
-              # Access private submodule via SSH.
-              # Based on https://github.com/actions/checkout/issues/116#issuecomment-1192418222.
-              env:
-                  SUBMODULE_REPO_DEPLOY_KEY: ${{ secrets.SUBMODULE_REPO_DEPLOY_KEY }}
-              run: |
-                  mkdir -p $HOME/.ssh
-                  echo $SUBMODULE_REPO_DEPLOY_KEY | base64 --decode > $HOME/.ssh/ssh.key
-                  chmod 600 $HOME/.ssh/ssh.key
-                  export GIT_SSH_COMMAND="ssh -i $HOME/.ssh/ssh.key"
-                  git submodule update --init --recursive
-                  unset GIT_SSH_COMMAND
+              with:
+                  submodules: recursive
+                  fetch-depth: 0
             - name: Setup Pages
               id: pages
               uses: actions/configure-pages@v5
@@ -82,6 +66,7 @@ jobs:
             url: ${{ steps.deployment.outputs.page_url }}
         runs-on: ubuntu-latest
         needs: build
+        if: github.ref == 'refs/heads/main'
         steps:
             - name: Deploy to GitHub Pages
               id: deployment

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "themes/event"] 
 	path = themes/event
-	url = git@github.com:medialesson/hugo-theme-event.git
+	url = https://github.com/medialesson/hugo-theme-event.git
   branch = main

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ See it in action on https://medialesson.github.io/hugo-theme-event-demo.
 ### Installation
 
 1. Open a shell of your choice.
-2. Clone this repository with SSH and submodules.
+2. Clone this repository with submodules.
     ```shell
-    git clone --recurse-submodules git@github.com:medialesson/hugo-theme-event-demo.git
+    git clone --recurse-submodules https://github.com/medialesson/hugo-theme-event-demo.git
     ```
-    **WARNING**: As the submodule requires authentication, you must clone the repository with SSH.
 3. Switch to the repository directory.
 4. Run npm install to install the required dependencies.
     ```shell


### PR DESCRIPTION
The theme repository is no public available. Therefore, it's not necessary anymore to integrate the submodule via SSH.