### PR TITLE
Use header menu also with long event titles

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -216,7 +216,7 @@ params:
         event:
             sessionizeId: 67poir7q
             title: medicon
-            shortTitle: medicon
+            shortTitle:
             startDate: 2025-01-30
             endDate: 2025-01-31
             address:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -216,6 +216,7 @@ params:
         event:
             sessionizeId: 67poir7q
             title: medicon
+            shortTitle: medicon
             startDate: 2025-01-30
             endDate: 2025-01-31
             address:


### PR DESCRIPTION
This PR focuses on enhancing the handling of event titles specifically in the header menu by integrating support for a shortened version of the event title (shortTitle). If a shortTitle is provided in the configuration, it will be used in the header menu in place of the full event title (title), improving readability in compact display areas.

![image](https://github.com/user-attachments/assets/d911ccf0-736d-4469-b090-c7fc0c48eef3)
